### PR TITLE
Fix VTX band letters initializer in SITL build

### DIFF
--- a/gym_pybullet_drones/assets/clone_bfs.sh
+++ b/gym_pybullet_drones/assets/clone_bfs.sh
@@ -30,6 +30,7 @@ cd temp/
 git checkout cafe727 #latest commit at the time of writing the gym-pybullet-drones Readme
 
 sed -i "s/delayMicroseconds_real(50);/\/\/delayMicroseconds_real(50);/g" ./src/main/main.c
+sed -i "s/\"-ABEFR\"/{ '-', 'A', 'B', 'E', 'F', 'R' }/g" ./src/main/drivers/vtx_table.c
 
 # Prepare
 make arm_sdk_install 

--- a/gym_pybullet_drones/envs/BetaAviary.py
+++ b/gym_pybullet_drones/envs/BetaAviary.py
@@ -85,7 +85,7 @@ class BetaAviary(BaseAviary):
         # Spawn SITL Betaflight instances (must have been created with assets/clone_bfs/sh first)
         for i in range(num_drones):
             FOLDER = os.path.dirname(os.path.abspath(__file__))+'/../../betaflight_sitl/bf'+str(i)+'/'
-            cmd = f"gnome-terminal -- bash -c 'cd {FOLDER} && ./obj/main/betaflight_SITL.elf; exec bash'"
+            cmd = f"bash -c 'cd {FOLDER} && ./obj/main/betaflight_SITL.elf; exec bash'"
             subprocess.Popen(cmd, shell=True)
         time.sleep(2)
         


### PR DESCRIPTION
./src/main/drivers/vtx_table.c:71:63: error: initializer-string for array of ‘char’ truncates NUL terminator but destination lacks ‘nonstring’ attribute (7 chars into 6 available) [-Werror=unterminated-string-initialization]
   71 | char           vtxTableBandLetters[VTX_TABLE_MAX_BANDS + 1] = "-ABEFR";

Fix build failure in vtx_table.c caused by "-ABEFR" string literal not fitting in VTX_TABLE_MAX_BANDS + 1 (6-byte buffer vs 7-byte string incl. NUL). Use character array initializer instead. This aligns with the official Betaflight repo VTX table representation.